### PR TITLE
BB-42-Redo-readBytes-method-in-ClassicBluetoothVescConnector-to-allow-populating-a-data-buffer-that-is-a-smaller-byte-size-than-the-total-bytes-available-from-the-input-stream

### DIFF
--- a/app/src/main/java/net/bobacktech/bionicboarder/comms/ClassicBluetoothVescConnector.kt
+++ b/app/src/main/java/net/bobacktech/bionicboarder/comms/ClassicBluetoothVescConnector.kt
@@ -59,12 +59,16 @@ class ClassicBluetoothVescConnector(
         var elapsedTime: Long
         while (totalBytesRead < numBytes) {
             val bytesAvailable = bluetoothSocket.inputStream.available()
-            if (bytesAvailable > 0) bluetoothSocket.inputStream.read(
-                data,
-                totalBytesRead,
-                bytesAvailable
-            )
-            totalBytesRead += bytesAvailable
+            val remainingSpace = numBytes - totalBytesRead
+            val bytesToRead = minOf(bytesAvailable, remainingSpace)
+            if (bytesAvailable > 0) {
+                bluetoothSocket.inputStream.read(
+                    data,
+                    totalBytesRead,
+                    bytesToRead
+                )
+                totalBytesRead += bytesToRead
+            }
             elapsedTime = SystemClock.elapsedRealtime() - startTime
             if (elapsedTime >= responseTimeout_ms) throw ResponseTimeoutException("Response timeout exceeded: $responseTimeout_ms ms")
         }


### PR DESCRIPTION
…from input stream into the data buffer.